### PR TITLE
Customize the identification field (slug)

### DIFF
--- a/config/roles.php
+++ b/config/roles.php
@@ -67,4 +67,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Field
+    |--------------------------------------------------------------------------
+    |
+    | Field in the database table that serves to identify the name of the 
+    | permission or role, is usually 'slug' but you can specify one of your 
+    | preference, eg: 'uuid'
+    |
+    */
+
+    'field' => 'slug'
+
 ];

--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -110,7 +110,7 @@ trait HasRoleAndPermission
     public function checkRole($role)
     {
         return $this->getRoles()->contains(function ($value) use ($role) {
-            return $role == $value->id || Str::is($role, $value->slug);
+            return $role == $value->id || Str::is($role, $value[config('roles.field')]);
         });
     }
 
@@ -282,7 +282,7 @@ trait HasRoleAndPermission
     public function checkPermission($permission)
     {
         return $this->getPermissions()->contains(function ($value) use ($permission) {
-            return $permission == $value->id || Str::is($permission, $value->slug);
+            return $permission == $value->id || Str::is($permission, $value[config('roles.field')]);
         });
     }
 


### PR DESCRIPTION
By default it considers the field slug, however sometimes it is necessary to consider another field, for example the uuid.

This small modification in the configuration file gives solution to the required