### PR TITLE
Fix bug on getRoles and getPermission

### DIFF
--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -44,7 +44,7 @@ trait HasRoleAndPermission
      */
     public function getRoles()
     {
-        return (!$this->roles) ? $this->roles = $this->roles()->get() : $this->roles;
+        return (null === $this->roles || $this->roles->isEmpty()) ? $this->roles = $this->roles()->get() : $this->roles;
     }
 
     /**
@@ -216,7 +216,7 @@ trait HasRoleAndPermission
      */
     public function getPermissions()
     {
-        return (!$this->permissions) ? $this->permissions = $this->rolePermissions()->get()->merge($this->userPermissions()->get()) : $this->permissions;
+        return (null === $this->permissions || $this->permissions->isEmpty()) ? $this->permissions = $this->rolePermissions()->get()->merge($this->userPermissions()->get()) : $this->permissions;
     }
 
     /**


### PR DESCRIPTION
  There was a bug that prevented the getRoles and getPermission methods from the 
  HasRoleAndPermission Trait to return the correct
  collection as !$this->roles or !$this->permissions was used to check
  for null and for empty collection at the same time,
  but !$this->anyCollection returns always false, even on empty collections.

  This is easyly testable on recently attached role to a user
  Ie:
    $user = User::create([...]);
    $role = Role::firstOrCreate([...]);
    $user->attachRole($role);
    $user->getRoles(); // Wrongly returns empty collection