### PR TITLE
minor fix for MS SQL server (group by alias)

### DIFF
--- a/src/Traits/HasRoleAndPermission.php
+++ b/src/Traits/HasRoleAndPermission.php
@@ -196,7 +196,7 @@ trait HasRoleAndPermission
             ->join('roles', 'roles.id', '=', 'permission_role.role_id')
             ->whereIn('roles.id', $this->getRoles()->pluck('id')->toArray())
             ->orWhere('roles.level', '<', $this->level())
-            ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'pivot_created_at', 'pivot_updated_at']);
+            ->groupBy(['permissions.id', 'permissions.name', 'permissions.slug', 'permissions.description', 'permissions.model', 'permissions.created_at', 'permissions.updated_at', 'permission_role.created_at', 'permission_role.updated_at']);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a small issue with MS SQL server. It seems as if grouping by a column alias is not supported by SQL server.

I did not test this fix with any other DBMS than MS SQL server. I don't see a reason why it should break compatibility with other DBMS, though, as operations on the actual column names should always work.